### PR TITLE
Fix plugin docs on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.16</version>
+        <version>4.29</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/Autonomiq-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/Autonomiq-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/Autonomiq-plugin</url>
+        <connection>scm:git:https://github.com/jenkinsci/autonomiq-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/autonomiq-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/autonomiq-plugin</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
# Fix plugin docs on plugins.jenkins.io

The plugin documentation extractor on https://plugins.jenkins.io needs to have the correct repository URL in the pom file that is released.  The plugin repository URLs need to be changed to use all lower case, since that is the form displayed by GitHub.

Plugin documentation on https://plugins.jenkins.io will be updated after the release of the plugin that includes this change.

This change also updates to use the most recent parent pom and to use the https:// protocol for the connection URL instead of using the git:// protocol.  GitHub has stated that they will be deprecating the git:// protocol.

* Use correct case for SCM urls in pom
* Use parent pom 4.29

@jameeluddin this will make the documentation visible on https://plugins.jenkins.io/autonomiq/ the next time you release the plugin.  It is a better experience for your users if they see the documentation on that page rather than needing to click one more link.  It also makes your plugin more easily found by the search facility on plugins.jenkins.io