### PR TITLE
Use plugin bill of materials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,9 @@
             <version>2.8.5</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>3.11.0</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
+            <version>3.14.9</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,54 +28,45 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.39</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.16</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -89,6 +80,17 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.303.x</artifactId>
+                <version>961.vf0c9f6f59827</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     
     <developers>
       <developer>


### PR DESCRIPTION
## Simplify dependency management with plugin BOM

* Manage dependencies with plugin bill of materials
* Use okhttp-api Jenkins plugin instead of library

The plugin bill of materials allows the plugin maintainer to rely on the plugin bom to provide version numbers for many common dependencies.  That avoids effort trying to find a set of version numbers that combine well for testing and simplifies plugin maintenance.

See https://github.com/jenkinsci/bom#readme for more details on the ways that plugin bill of materials can help.

Use okhttp-api Jenkins plugin instead of library

Switch the okhttp dependency from bundling the okhttp jar file inside the plugin to use the Jenkins okhttp-api plugin that is already installed on many Jenkins controllers.  Reduces the size of the plugin and assures that the okhttp library version is consistent with the library used in other Jenkins plugins.

Supersedes pull requests #9, #8, #5, #4, #3, and #1.

@jameeluddin this will make plugin dependency management simpler for you as a maintainer.